### PR TITLE
Make gen more strict about being called exactly once

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ run(function* (gen) {
 });
 ```
 
-This alternate API can be mixed and matched with continuable style APIs.  If you yield a function, it will assume it's a continuable and pass in a callback.  If you don't, it's your responsibility to pass in the generated callback manually in the right place.
+This alternate API can be mixed and matched with continuable style APIs.  If you call `gen()`, you still have to yield afterwards, but the actual yielded value will be ignored.  If you don't call `gen()`, you have to yield a continuable function, which will be called by gen-run appropriately.
 
 If you want to use delegate yield with the explicit style it's up to you to pass the `gen` function to the child generator.
 

--- a/run.js
+++ b/run.js
@@ -10,10 +10,10 @@ function run(generator, callback) {
   next();
   check();
   
-  function nextSafe(item) {
+  function nextSafe(err, item) {
     var n;
     try {
-      n = iterator.next(item);
+      n = (err ? iterator.throw(err) : iterator.next(item));
       if (!n.done) {
         if (typeof n.value === "function") n.value(resume());
         yielded = true;
@@ -26,8 +26,8 @@ function run(generator, callback) {
     return callback(null, n.value);
   }
 
-  function nextPlain(item) {
-    var cont = iterator.next(item).value;
+  function nextPlain(err, item) {
+    var cont = (err ? iterator.throw(err) : iterator.next(item)).value;
     // Pass in resume to continuables if one was yielded.
     if (typeof cont === "function") cont(resume());
     yielded = true;
@@ -49,8 +49,7 @@ function run(generator, callback) {
       var item = data[1];
       data = null;
       yielded = false;
-      if (err) return iterator.throw(err);
-      next(item);
+      next(err, item);
       yielded = true;
     }
   }

--- a/test.js
+++ b/test.js
@@ -68,39 +68,42 @@ function* nowrap_sub(gen, n) {
 
 function *run_with_callback(gen) {
   console.log("Callback");
+  var resume = gen();
   yield run(function* (gen) {
     yield sleep(1000);
     return "Hello";
   }, function (err, value) {
     console.log("Callback err: " + err);
     console.log("Callback value: " + value);
-    gen()(err, value);
+    resume(err, value);
   });
   testRun("run_with_callback_exception", run_with_callback_exception);
 }
 
 function *run_with_callback_exception(gen) {
   console.log("Callback err");
+  var resume = gen();
   yield run(function *(gen) {
     yield sleep(1000);
     throw new Error("Some error");
   }, function (err, value) {
     console.log("Callback err: " + err);
     console.log("Callback value: " + value);
-    gen()(null, value); // Intentionally suppress the error
+    resume(null, value); // Intentionally suppress the error
   });
   testRun("run_with_callback_early_exception", run_with_callback_early_exception);
 }
 
 function *run_with_callback_early_exception(gen) {
   console.log("Callback err");
+  var resume = gen();
   yield run(function *(gen) {
     throw new Error("Some error");
     yield sleep(1000);
   }, function (err, value) {
     console.log("Callback err: " + err);
     console.log("Callback value: " + value);
-    gen()(null, value); // Intentionally suppress the error
+    resume(null, value); // Intentionally suppress the error
   });
   testRun("run_with_thrown_error", run_with_thrown_error);
 }

--- a/test.js
+++ b/test.js
@@ -70,7 +70,7 @@ function *run_with_callback(gen) {
   console.log("Callback");
   yield run(function* (gen) {
     yield sleep(1000);
-    return "Hello"
+    return "Hello";
   }, function (err, value) {
     console.log("Callback err: " + err);
     console.log("Callback value: " + value);
@@ -102,7 +102,25 @@ function *run_with_callback_early_exception(gen) {
     console.log("Callback value: " + value);
     gen()(null, value); // Intentionally suppress the error
   });
-  console.log("End");
+  testRun("run_with_thrown_error", run_with_thrown_error);
+}
+
+function *run_with_thrown_error(gen) {
+  var inCatch = false;
+  try {
+    yield sleep(1);
+    yield fail();
+    console.error("this should not happen!");
+  }
+  catch (err) {
+    console.log("in catch: " + err);
+    console.assert(err);
+    inCatch = true;
+  }
+  yield sleep(1);
+  console.log("yielded after catch");
+  console.assert(inCatch);
+  console.log("\nEnd");
 }
 
 function sleep(ms) {
@@ -117,7 +135,13 @@ function evil() {
     setTimeout(function () {
       callback(null, 2);
     }, 100);
-  }
+  };
+}
+
+function fail() {
+  return function (callback) {
+    callback(Error("throwing error into generator"));
+  };
 }
 
 function decrement(n) {


### PR DESCRIPTION
This pull request is branched off from #7. You probably want to look at 0eeee5f894face8b84d6f8ee70710cf0e68546e7, not the combined diff of both this and #7. If you want to merge it without #7, tell me and I'll rebase it.

What this commit does, and why:
- Protects against errors caused by incorrect usage. Correct library clients should be mostly unaffected. Ensures that gen is called at most once before the generator yields, and if it is not called, the generator has to yield a continuable.
- Fixes yielding weird async functions that receive a callback, but return a function value. Imagine a hypothetical setTimeout that doesn't return an integer, but a function that cancels the timeout when called. Yeah, I've never seen one either, this was mostly a side effect...
- Renames "resume" to "gen", to follow the README. The idea is that "resume" is what the anonymous function returned by "gen" is called. If you don't like the rename, I can separate it from the rest of the commit.
- Modifies tests so that they don't use `gen()(null, value)`. You're not supposed to do that: it circumvents the `done` check in resume. The new checks correctly detected that the tests didn't call gen before yielding nor yield a continuable.
- Removes useless `yielded = true` line from `check`.
